### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/md_lint.yaml
+++ b/.github/workflows/md_lint.yaml
@@ -1,6 +1,8 @@
 # A GitHub Action to run Markdown linting on pull requests and pushes using markdownlint.
 ---
 name: Markdown Lint
+permissions:
+  contents: read
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/ONS-Innovation/codespace-poc/security/code-scanning/1](https://github.com/ONS-Innovation/codespace-poc/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only performs Markdown linting and does not require write access, we will set the `contents` permission to `read`. This ensures the workflow adheres to the principle of least privilege while maintaining its functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
